### PR TITLE
Repeat unlock 60 times

### DIFF
--- a/files/helper.sh
+++ b/files/helper.sh
@@ -10,7 +10,6 @@ diskutil apfs list -plist \
 	| xsltproc --novalid "${0%/*}/diskutil.xsl" - \
 	| grep -E ':true:true$' \
 	| cut -f1-3 -d':' \
-	| tee /dev/stderr \
 	| while IFS=: read NAME UUID DEVICE ; do
 		printf 'Trying to unlock volume "%s" with UUID %s ...\n' "$NAME" "$UUID"
 		if ! PASSPHRASE=$(${0%/*}/BootUnlock find-generic-password \

--- a/files/helper.sh
+++ b/files/helper.sh
@@ -5,10 +5,12 @@ set -eu -o pipefail
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 
 echo "=== $(date) ==="
+for i in {1..60}; do
 diskutil apfs list -plist \
 	| xsltproc --novalid "${0%/*}/diskutil.xsl" - \
 	| grep -E ':true:true$' \
 	| cut -f1-3 -d':' \
+	| tee /dev/stderr \
 	| while IFS=: read NAME UUID DEVICE ; do
 		printf 'Trying to unlock volume "%s" with UUID %s ...\n' "$NAME" "$UUID"
 		if ! PASSPHRASE=$(${0%/*}/BootUnlock find-generic-password \
@@ -28,3 +30,5 @@ diskutil apfs list -plist \
 			continue
 		fi
 	done
+        sleep 1
+done

--- a/files/helper.sh
+++ b/files/helper.sh
@@ -29,6 +29,6 @@ diskutil apfs list -plist \
 			echo "ERROR: could not unlock volume '$NAME', skipping the volume." >&2
 			continue
 		fi
-	done
+	done || true
         sleep 1
 done


### PR DESCRIPTION
I noticed not all my (encrypted) external drives show up at the first `diskutil apfs list` and therefore most of my reboots failed to unlock and mount home drive.  This PR addresses the issue in a (pretty ugly but) simple way by trying the unlock 60 times waiting for a second after each attempt.

Also due to `set -o pipefail` when `grep` does not find any encrypted drives the script was aborting which has been suppressed by `|| true`

(bash nit: ending a line with `|` makes the backslashes at the end of every line unnecessary.  But I didn't want to make this PR's diff appear complicated.)