### PR TITLE
- Added support for ARM-based Macs (e.g. Macbook Pro M2);

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.3.0
+-----
+
+- Added support for ARM-based Macs (e.g. Macbook Pro M2);
+- Added the "preinstall" script with a check and a conditional installation of
+  the Xcode command-line tools;
+- changed the way BootUnlock binary is created from /usr/sbin/security, now
+  the lipo tool is used to extract the x86_64 part from the universal Mach-O
+  binary.  This allows running it with a adhoc signature on the ARM-based Macs.
+
 1.2.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,36 @@ Alternatively, if you do not want to build the package yourself, you can grab th
 premade one from the [releases](../../releases) section here.
 
 To install the package just open it in Finder and follow the installation prompts.
+
+## Use case
+
+The typical usage scenario is the following:
+
+1. One adds a dedicated encrypted APFS volume to hold home directories for the
+   normal users on the system (e.g. by going to the Disk Utility application and
+   adding a volume over there as an administrator);
+2. The newly created volume is manually mounted by the administrator;
+3. Then the required home directories need to be moved over to that new volume
+   (use Finder as an administrator and drag and drop the folders, this will
+   ensure that all the necessary permissions and extended attributes are
+   preserved -- you cannot easily copy over a home directory via the Terminal
+   application, unfortunately);
+4. Now, to modify the home directory for the required users, one need to open
+   System Setting (or System Preferences in older macOS versions), find the
+   "Users & Groups" section, and after right-clicking on a user account, select
+   "Advanced Options ...": there the home directory can be changed to point to
+   the new volume;
+5. Finally, this is where BootUnlock comes in: to automatically unlock the newly
+   created volume for home directories upon the user login, install BootUnlock
+   and specify the password for the volume during the installation.
+
+This approach allows you to easily upgrade macOS (or even run different versions
+of macOS on different APFS volumes), yet have your user data intact and in one
+place.  For example, you may want to trial a new beta of macOS by creating a new
+APFS volume, installing the beta over there, then attach the volume with home
+directories to that new installation, and update your account in the beta to use
+the home directory on that volume: your home will be shared between two versions
+of macOS with all the settings preserved.  There is a slight chance that the new
+macOS version may make an incompatible change to the preferences which would not
+be recognised by the older version, but I was running Yosemite, Big Sur, Catalina,
+and Monterey -- switching between them regularly and did not experience any issues.

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -13,8 +13,11 @@ INSTALL_LOCATION="/Library/PrivilegedHelperTools/$IDENTIFIER"
 
 LAUNCH_DAEMON_PLIST="/Library/LaunchDaemons/$IDENTIFIER.plist"
 
-# Here is the trick: we are abusing the security(1) tool to access items on keychain in a secure way :)
-cp /usr/bin/security "$INSTALL_LOCATION/$NAME"
+# Here is the trick: we are abusing the security(1) tool to access items on
+# keychain in a secure way :).  Unfortunately, on ARM-based Macs only Apple
+# signed binaries can run arm64e (since Apple considers that ABI to be unstable),
+# therefore, to make it work we are only using the x86_64 binary part.
+xcrun lipo /usr/bin/security -thin x86_64 -output "$INSTALL_LOCATION/$NAME"
 codesign -f -s - "--prefix=${IDENTIFIER%$NAME}" -r="designated => identifier $IDENTIFIER" "$INSTALL_LOCATION/$NAME"
 chown -h root:wheel "$INSTALL_LOCATION/$NAME"
 chmod 0100 "$INSTALL_LOCATION/$NAME"

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+if ! xcode-select -p >/dev/null 2>&1; then
+	xcode-select --install ||:
+fi


### PR DESCRIPTION
- Added the "preinstall" script with a check and a conditional installation of the Xcode command-line tools;
- changed the way BootUnlock binary is created from /usr/sbin/security, now the lipo tool is used to extract the x86_64 part from the universal Mach-O binary.  This allows running it with a adhoc signature on the ARM-based Macs.
- Updated README.md with the use case.